### PR TITLE
Enhancement: Implement DataSanitizer/LogCleaner scrub methods, fix CommandFlags parsing, add tests [6]


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 2025-04-29
+
+### Added
+- Implemented `scrub` methods in `DataSanitizer` and `LogCleaner` classes for text sanitization [*](https://github.com/David-Parry/ai-assited/pull/32)
+
+### Fixed
+- Fixed flag parsing logic in `CommandFlags` to correctly handle flags with and without values
+
+### Changed
+- Enhanced text sanitization with regex pattern matching using word boundaries

--- a/src/main/java/ai/qodo/joke/CommandFlags.java
+++ b/src/main/java/ai/qodo/joke/CommandFlags.java
@@ -17,13 +17,11 @@ public class CommandFlags {
                 String arg = args[i];
                 if (arg.startsWith("-")) {
                     String flag = arg.substring(1);
-                    String value = null;
                     if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-                        value = args[i + 1];
-                        flags.put(flag, Optional.ofNullable(args[i + 1]));
-                        i++; // Skip the value in the next iteration
+                        flags.put(flag, Optional.ofNullable(args[++i]));
+                    } else {
+                        flags.put(flag, Optional.empty());
                     }
-                    //flags.put(flag, value);
                 }
             }
         }

--- a/src/main/java/ai/qodo/joke/DataSanitizer.java
+++ b/src/main/java/ai/qodo/joke/DataSanitizer.java
@@ -1,10 +1,41 @@
 package ai.qodo.joke;
 
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class DataSanitizer implements Scrubber {
 
+
     @Override
     public String scrub(String joke) {
-        return null;
+        // Throw NullPointerException if joke is null as specified in the javadoc
+        Objects.requireNonNull(joke, "Joke cannot be null");
+
+        if (joke.isEmpty()) {
+            return joke;
+        }
+
+        // Build a regex pattern from the swearWords set, handling case insensitivity and word boundaries
+        StringBuilder patternBuilder = new StringBuilder();
+        boolean first = true;
+        for (String word : swearWords) {
+            if (!first) {
+                patternBuilder.append("|");
+            }
+            patternBuilder.append("\\b").append(Pattern.quote(word)).append("\\b");
+            first = false;
+        }
+
+        if (patternBuilder.length() == 0) {
+            // No swear words defined; nothing to redact
+            return joke;
+        }
+
+        Pattern pattern = Pattern.compile(patternBuilder.toString(), Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(joke);
+
+        // Replace each match with REDACTED_WORD from the interface constant
+        return matcher.replaceAll(REDACTED_WORD);
     }
 }

--- a/src/main/java/ai/qodo/joke/LogCleaner.java
+++ b/src/main/java/ai/qodo/joke/LogCleaner.java
@@ -9,8 +9,14 @@ public class LogCleaner implements Scrubber {
 
     @Override
     public String scrub(String joke) {
-        if (joke == null) {
-            throw new NullPointerException("Input joke must not be null");
+        @Override
+        public String scrub(String joke) {
+            Objects.requireNonNull(joke, "Input joke must not be null");
+    
+            // Split on word boundaries, replace swear words, and rejoin
+            return Arrays.stream(joke.split("\\b"))
+                    .map(word -> swearWords.contains(word.toLowerCase()) ? REDACTED_WORD : word)
+                    .collect(Collectors.joining());
         }
         
         // Split on word boundaries, replace swear words, and rejoin

--- a/src/main/java/ai/qodo/joke/LogCleaner.java
+++ b/src/main/java/ai/qodo/joke/LogCleaner.java
@@ -1,10 +1,21 @@
 package ai.qodo.joke;
 
+import java.util.Set;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class LogCleaner implements Scrubber {
+    
 
     @Override
     public String scrub(String joke) {
-        return null;
+        if (joke == null) {
+            throw new NullPointerException("Input joke must not be null");
+        }
+        
+        // Split on word boundaries, replace swear words, and rejoin
+        return Arrays.stream(joke.split("\\b"))
+                .map(word -> swearWords.contains(word.toLowerCase()) ? REDACTED_WORD : word)
+                .collect(Collectors.joining());
     }
 }

--- a/src/test/groovy/ai/qodo/joke/CommandFlagsSpec.groovy
+++ b/src/test/groovy/ai/qodo/joke/CommandFlagsSpec.groovy
@@ -4,4 +4,35 @@ import spock.lang.Specification
 
 class CommandFlagsSpec extends Specification {
 
+
+        // Parse command line arguments with flags and values correctly
+        def "should parse flags with values correctly"() {
+            given:
+            String[] args = ["-verbose", "true", "-count", "5", "-quiet"]
+
+            when:
+            CommandFlags commandFlags = new CommandFlags(args)
+
+            then:
+            commandFlags.hasFlag("verbose") == true
+            commandFlags.getFlagValue("verbose").get() == "true"
+            commandFlags.hasFlag("count") == true
+            commandFlags.getFlagValue("count").get() == "5"
+            commandFlags.hasFlag("quiet") == true
+            commandFlags.getFlagValue("quiet").isEmpty()
+            commandFlags.hasFlag("nonexistent") == false
+            commandFlags.getFlagValue("nonexistent").isEmpty()
+        }
+
+        // Handle null input in constructor
+        def "should handle null input in constructor"() {
+            when:
+            CommandFlags commandFlags = new CommandFlags(null)
+
+            then:
+            commandFlags.hasFlag("any") == false
+            commandFlags.getFlagValue("any").isEmpty()
+            commandFlags.toString() == "CommandFlags{flags={}}"
+        }
+
 }


### PR DESCRIPTION
### **User description**
…sSpec tests; fix CommandFlags flag parsing logic


___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Implemented `scrub` methods in `DataSanitizer` and `LogCleaner` classes
  - `DataSanitizer` now redacts swear words using regex with word boundaries
  - `LogCleaner` replaces swear words by splitting on word boundaries

- Fixed flag parsing logic in `CommandFlags`
  - Ensures correct association of flags and their values
  - Handles flags without values appropriately

- Added comprehensive Spock tests for `CommandFlags`
  - Tests flag parsing, value retrieval, and null input handling


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataSanitizer.java</strong><dd><code>Implement swear word redaction in DataSanitizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/DataSanitizer.java

<li>Implemented the <code>scrub</code> method to redact swear words using regex.<br> <li> Handles null and empty input as specified.<br> <li> Uses word boundaries and case insensitivity for accurate redaction.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/32/files#diff-9a3cf2444900974382976ab963114186fe2126e37d0244c8b67e0db39773165f">+33/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogCleaner.java</strong><dd><code>Add swear word scrubbing logic to LogCleaner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/LogCleaner.java

<li>Implemented the <code>scrub</code> method to redact swear words.<br> <li> Splits input on word boundaries and replaces swear words.<br> <li> Throws NullPointerException for null input.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/32/files#diff-6bf006de590f569647095367e6ee0a4ffcc02320bf6d3aea6340fec9b2deae11">+13/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandFlags.java</strong><dd><code>Fix and improve CommandFlags flag parsing logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/CommandFlags.java

<li>Fixed flag parsing logic to correctly associate flags and values.<br> <li> Ensures flags without values are handled as empty.<br> <li> Minor code cleanup and formatting.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/32/files#diff-b8f40cf8f1b5cbbe25f5a29d2ac8e4a42e88fe5c403692a3effcd775c8ec2b59">+4/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommandFlagsSpec.groovy</strong><dd><code>Add comprehensive tests for CommandFlags parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/groovy/ai/qodo/joke/CommandFlagsSpec.groovy

<li>Added Spock tests for flag parsing and value retrieval.<br> <li> Tests handling of null input and string representation.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/32/files#diff-23ef02c91244d2edceb28fcf58c25b6af2a12b9bc27c84cac5af59cbc23c67bb">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>