### PR TITLE
Enhancement: Add swear word redaction to DataSanitizer and LogCleaner [Estimate: 3]


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 2025-05-05
+
+### Added
+- Added swear word redaction functionality to DataSanitizer and LogCleaner [*](https://github.com/David-Parry/ai-assited/pull/34)
+- Implemented word boundary matching for accurate swear word detection
+- Added null safety checks for input strings

--- a/src/main/java/ai/qodo/joke/DataSanitizer.java
+++ b/src/main/java/ai/qodo/joke/DataSanitizer.java
@@ -1,10 +1,20 @@
 package ai.qodo.joke;
 
+import java.util.Objects;
 
 public class DataSanitizer implements Scrubber {
 
     @Override
     public String scrub(String joke) {
-        return null;
+        Objects.requireNonNull(joke, "Joke cannot be null");
+
+        String result = joke;
+        for (String word : swearWords) {
+            // Replace the word with REDACTED
+            // Using word boundary to ensure we match whole words only
+            result = result.replaceAll("(?i)\\b" + word + "\\b", REDACTED_WORD);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/ai/qodo/joke/LogCleaner.java
+++ b/src/main/java/ai/qodo/joke/LogCleaner.java
@@ -1,10 +1,27 @@
 package ai.qodo.joke;
 
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.List;
 
 public class LogCleaner implements Scrubber {
+    
+    private static final String REDACTED_WORD = "REDACTED";
+    private static final List<String> swearWords = Arrays.asList(
+        "damn", "hell", "crap", "ass", "shit", "bitch"
+    );
 
     @Override
     public String scrub(String joke) {
-        return null;
+        Objects.requireNonNull(joke, "Joke cannot be null");
+        
+        String result = joke;
+        for (String word : swearWords) {
+            // Replace the word with REDACTED
+            // Using word boundary to ensure we match whole words only
+            result = result.replaceAll("\\b" + word + "\\b", REDACTED_WORD);
+        }
+        
+        return result;
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Implemented `scrub` method in `DataSanitizer` and `LogCleaner`

- Added logic to redact swear words with "REDACTED"

- Ensured null safety using `Objects.requireNonNull`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataSanitizer.java</strong><dd><code>Add swear word redaction logic to DataSanitizer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/DataSanitizer.java

<li>Implemented <code>scrub</code> method to redact swear words<br> <li> Used word boundaries for accurate matching<br> <li> Added null check for input string


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/34/files#diff-9a3cf2444900974382976ab963114186fe2126e37d0244c8b67e0db39773165f">+12/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogCleaner.java</strong><dd><code>Implement swear word filtering in LogCleaner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/LogCleaner.java

<li>Implemented <code>scrub</code> method to redact swear words<br> <li> Defined list of swear words to filter<br> <li> Used word boundaries and null check for input


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/34/files#diff-6bf006de590f569647095367e6ee0a4ffcc02320bf6d3aea6340fec9b2deae11">+19/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>