### PR TITLE
Enhancement: Implement scrub functionality for DataSanitizer and LogCleaner [Estimate: 3]


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 2025-05-29
 
 ### Added
+- Implemented scrub functionality in DataSanitizer and LogCleaner classes [*](https://github.com/David-Parry/ai-assited/pull/43)
+- Added content filtering to replace inappropriate words with redacted text
+- Added null input validation with appropriate exception handling
+
+## 2025-05-29
+
+### Added
 - Implemented scrub functionality in DataSanitizer and LogCleaner classes [*](https://github.com/David-Parry/ai-assited/pull/42)
 - Added content filtering to replace inappropriate words with redacted text
 - Added null input validation with appropriate exception handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 2025-05-29
+
+### Added
+- Implemented scrub functionality in DataSanitizer and LogCleaner classes [*](https://github.com/David-Parry/ai-assited/pull/41)
+- Added content filtering to replace inappropriate words with redacted text
+- Added null input validation with appropriate exception handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 ## 2025-05-29
 
 ### Added
+- Implemented scrub functionality in DataSanitizer and LogCleaner classes [*](https://github.com/David-Parry/ai-assited/pull/42)
+- Added content filtering to replace inappropriate words with redacted text
+- Added null input validation with appropriate exception handling
+
+## 2025-05-29
+
+### Added
 - Implemented scrub functionality in DataSanitizer and LogCleaner classes [*](https://github.com/David-Parry/ai-assited/pull/41)
 - Added content filtering to replace inappropriate words with redacted text
 - Added null input validation with appropriate exception handling

--- a/src/main/java/ai/qodo/joke/DataSanitizer.java
+++ b/src/main/java/ai/qodo/joke/DataSanitizer.java
@@ -5,6 +5,29 @@ public class DataSanitizer implements Scrubber {
 
     @Override
     public String scrub(String joke) {
-       return null;
+        if (joke == null) {
+            throw new NullPointerException("Joke cannot be null");
+        }
+        
+        String[] words = joke.split("\\s+");
+        StringBuilder result = new StringBuilder();
+        
+        for (int i = 0; i < words.length; i++) {
+            String word = words[i].toLowerCase();
+            // Remove punctuation for checking but keep original for replacement
+            String cleanWord = word.replaceAll("[^a-zA-Z]", "");
+            
+            if (swearWords.contains(cleanWord)) {
+                result.append(REDACTED_WORD);
+            } else {
+                result.append(words[i]);
+            }
+            
+            if (i < words.length - 1) {
+                result.append(" ");
+            }
+        }
+        
+        return result.toString();
     }
 }

--- a/src/main/java/ai/qodo/joke/LogCleaner.java
+++ b/src/main/java/ai/qodo/joke/LogCleaner.java
@@ -5,6 +5,29 @@ public class LogCleaner implements Scrubber {
 
     @Override
     public String scrub(String joke) {
-        return null;
+        if (joke == null) {
+            throw new NullPointerException("Joke cannot be null");
+        }
+        
+        String[] words = joke.split("\\s+");
+        StringBuilder result = new StringBuilder();
+        
+        for (int i = 0; i < words.length; i++) {
+            String word = words[i].toLowerCase();
+            // Remove punctuation for checking but keep original for replacement
+            String cleanWord = word.replaceAll("[^a-zA-Z]", "");
+            
+            if (swearWords.contains(cleanWord)) {
+                result.append(REDACTED_WORD);
+            } else {
+                result.append(words[i]);
+            }
+            
+            if (i < words.length - 1) {
+                result.append(" ");
+            }
+        }
+        
+        return result.toString();
     }
 }


### PR DESCRIPTION
### **Mermaid diagrams**
### Class Diagram: Scrubber Implementation

```mermaid
classDiagram
    class Scrubber {
        <<interface>>
        +scrub(String joke) String
    }
    class DataSanitizer {
        +scrub(String joke) String
    }
    class LogCleaner {
        +scrub(String joke) String
    }
    Scrubber <|.. DataSanitizer
    Scrubber <|.. LogCleaner
```

### Sequence Diagram: Scrub Method Flow

```mermaid
sequenceDiagram
    participant Caller
    participant ScrubberImpl as DataSanitizer/LogCleaner
    Caller->>ScrubberImpl: scrub(joke)
    alt joke is null
        ScrubberImpl-->>Caller: throw NullPointerException
    else joke is not null
        ScrubberImpl->>ScrubberImpl: split joke into words
        loop for each word
            ScrubberImpl->>ScrubberImpl: check if word (cleaned) is in swearWords
            alt is swear word
                ScrubberImpl->>ScrubberImpl: append REDACTED_WORD
            else not swear word
                ScrubberImpl->>ScrubberImpl: append original word
            end
        end
        ScrubberImpl-->>Caller: return redacted string
    end
```


___

### **PR Type**
Enhancement


___

### **Description**
- Implemented `scrub` method in `DataSanitizer` and `LogCleaner`
  - Replaces swear words with redacted text
  - Handles null input with exception

- Updated `CHANGELOG.md` with new features and changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DataSanitizer.java</strong><dd><code>Add scrub logic and input validation to DataSanitizer</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/DataSanitizer.java

<li>Implemented the <code>scrub</code> method.<br> <li> Replaces swear words with a redacted constant.<br> <li> Handles null input with NullPointerException.<br> <li> Preserves original word formatting except for redacted words.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/43/files#diff-9a3cf2444900974382976ab963114186fe2126e37d0244c8b67e0db39773165f">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LogCleaner.java</strong><dd><code>Add scrub logic and input validation to LogCleaner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/ai/qodo/joke/LogCleaner.java

<li>Implemented the <code>scrub</code> method.<br> <li> Redacts swear words using a defined constant.<br> <li> Throws NullPointerException for null input.<br> <li> Maintains original word formatting except for redacted words.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/43/files#diff-6bf006de590f569647095367e6ee0a4ffcc02320bf6d3aea6340fec9b2deae11">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with scrub feature and filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entries for new scrub functionality.<br> <li> Documented content filtering and exception handling.<br> <li> Linked to relevant PRs for traceability.


</details>


  </td>
  <td><a href="https://github.com/David-Parry/ai-assited/pull/43/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>